### PR TITLE
fix(database): remove redundant session.close() call

### DIFF
--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -42,8 +42,6 @@ async def get_db() -> AsyncSession:
             logger.error(f"Database session error: {e}")
             await session.rollback()
             raise
-        finally:
-            await session.close()
 
 # Test database connection
 async def test_db_connection():


### PR DESCRIPTION
The `get_db` dependency was explicitly calling `await session.close()` in a `finally` block, which is redundant when using an `async with` statement to manage the session. This likely interfered with the connection pool and caused a connection leak, leading to 'Max client connections reached' errors.

This commit removes the `finally` block, relying on the `async with` context manager to handle the session lifecycle correctly. This should resolve the database connection leak.