### PR TITLE
fix(database): add pool_timeout to database engine

### DIFF
--- a/backend/core/database.py
+++ b/backend/core/database.py
@@ -17,6 +17,7 @@ engine = create_async_engine(
     max_overflow=10,
     pool_pre_ping=True,
     pool_recycle=300,
+    pool_timeout=30,
     future=True,
 )
 


### PR DESCRIPTION
The application is frequently hitting the 'Max client connections reached' error, which suggests that the database connection pool is being exhausted.

This commit adds a `pool_timeout=30` to the `create_async_engine` call. This will prevent requests from waiting indefinitely for a database connection, making the application more resilient to high load and potential connection leaks. While the root cause might be a restrictive `max_connections` setting on the database, this change will help mitigate the impact of this issue.